### PR TITLE
Fix absence of default options value

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -7,7 +7,7 @@ import imageminGifsicle from 'imagemin-gifsicle'
 import imageminJpegtran from 'imagemin-jpegtran'
 import imageminSvgo from 'imagemin-svgo'
 
-function ImageminPlugin (options) {
+function ImageminPlugin (options = {}) {
   // I love ES2015!
   const {
     disable = false,


### PR DESCRIPTION
When running plugin without any options getting this error: `TypeError: Cannot read property 'disable' of undefined` because the `options` argument of the plugin constructor are undefined by default.