### PR TITLE
Add error handling

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -73,9 +73,11 @@ ImageminPlugin.prototype.apply = function (compiler) {
             // https://github.com/webpack/compression-webpack-plugin/blob/ee8e701e47b2f488da32b135abe88a47972487de/index.js#L82
             assets[filename] = new RawSource(optimizedAssetContents)
           })
+          .catch((err) => callback(err))
       }))
       // And once everything is done, go ahead and call the callback.
       .then(() => callback())
+      .catch((err) => callback(err))
     })
   })
 }


### PR DESCRIPTION
Hi! 😃

I've been using this plugin and I had an issue that my webpack build task would fail silently, without showing any errors. I found out it was because this plugin wasn't catching errors, passing them to the callback. This PR fixes it.

Let me know what you think!

Thanks