### PR TITLE
Limit the number of concurrent imagemin processes to the number of CPUs

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ module.exports = {
       },
       svgo: {
       },
-      pngquant: null, // pngquant is not run unless you pass options here,
+      pngquant: null, // pngquant is not run unless you pass options here
       plugins: []
     })
   ]

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ module.exports = {
       },
       svgo: {
       },
-      pngquant: null, // pngquant is not run unless you pass options here
+      pngquant: null, // pngquant is not run unless you pass options here,
       plugins: []
     })
   ]
@@ -52,6 +52,13 @@ To disable a default plugin, pass `null` as it's option object. For example, the
 ``` js
 {
   svgo: null
+}
+```
+
+At default it would spawn an imagemin process for each cpu-core. But you can override it with maxConcurrency:
+```js
+{
+  maxConcurrency: 2
 }
 ```
 

--- a/index.js
+++ b/index.js
@@ -30,6 +30,7 @@ function ImageminPlugin (options = {}) {
 
   this.options = {
     disable,
+    maxConcurrency,
     imageminOptions: {
       plugins: []
     }

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
   },
   "homepage": "https://github.com/Klathmon/imagemin-webpack-plugin#readme",
   "dependencies": {
+    "async-throttle": "0.0.1",
     "babel-runtime": "6.11.6",
     "imagemin": "^5.2.1",
     "imagemin-gifsicle": "^5.1.0",


### PR DESCRIPTION
fixes issue as described in #11 .

* new option maxConcurrency
* default with cpu-cores

i tested i local with a basic-testsetup, but i think it would be nice, if you could test it again please 👍 

maybe it would be good, to have some unit-tests for the feature 😄 