### PR TITLE
fix: Resolve issue with incorrect destination filenames

### DIFF
--- a/index.js
+++ b/index.js
@@ -145,6 +145,7 @@ async function optimizeExternalImages (throttle, sources, destination, minFileSi
       if (typeof destination !== 'string') {
         destination = '.'
       }
+      filename = path.basename(filename);
       const writeFilePath = path.normalize(`${destination}/${filename}`)
 
       return writeFile(writeFilePath, optimizedImageBuffer)


### PR DESCRIPTION
optimizeExternalImages function concatenates the entire filename in the sources list to the destination, leading to an incorrect destination.

E.g:

```
externalImages: {
    sources: [
        'foo/bar/source/example.jpg',
    ],
    destination: 'foo/bar/dist',
}
```

Leads to: foo/bar/dist/foo/bar/source/example.jpg