### PR TITLE
Use Webpack Context

### DIFF
--- a/src/helpers.js
+++ b/src/helpers.js
@@ -65,7 +65,7 @@ export function buildTestFunction (rawTestValue, minFileSize, maxFileSize) {
  * @param  {string} filePath The path (relative or absolute) to the file
  * @return {string}          A hash of the full file path
  */
-export async function hashFilename (filePath) {
+export function hashFilename (filePath) {
   return crypto.createHash('sha1').update(filePath).digest('hex')
 }
 
@@ -95,7 +95,7 @@ export function invokeIfFunction (func) {
 export async function getFromCacheIfPossible (context, cacheFolder, filename, elseFunc) {
   let cacheFilePath
   if (cacheFolder !== null) {
-    cacheFilePath = path.join(context, cacheFolder, hashFilename(filename))
+    cacheFilePath = path.resolve(context, cacheFolder, hashFilename(filename))
     if (await exists(cacheFilePath)) {
       return readFile(cacheFilePath)
     }

--- a/src/index.js
+++ b/src/index.js
@@ -151,17 +151,17 @@ export default class ImageminPlugin {
       cacheFolder
     } = this.options
 
-    const invokedDestination = path.join(context, invokeIfFunction(destination))
+    const invokedDestination = path.resolve(context, invokeIfFunction(destination))
 
     return map(invokeIfFunction(sources), (filename) => throttle(async () => {
       const relativeFilePath = path.relative(context, filename)
-      const fileData = await readFile(path.join(context, relativeFilePath))
+      const fileData = await readFile(path.resolve(context, relativeFilePath))
       if (testFunction(filename, fileData)) {
         const writeFilePath = path.join(invokedDestination, relativeFilePath)
 
         // Use the helper function to get the file from cache if possible, or
         // run the optimize function and store it in the cache when done
-        let optimizedImageBuffer = await getFromCacheIfPossible(cacheFolder, relativeFilePath, async () => {
+        let optimizedImageBuffer = await getFromCacheIfPossible(context, cacheFolder, relativeFilePath, async () => {
           return optimizeImage(fileData, this.options.imageminOptions)
         })
 


### PR DESCRIPTION
This is a PR to enable use of the `context` option in webpack which allows you to set the "root" directory for the whole process differently than the current working directory.

This also fixes a few bugs with absolute paths anywhere that paths were used in the plugin (mostly in the `externalImages` option)