### PR TITLE
add fileName option for externalImages

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ module.exports = {
 #### options.externalImages
 
 **type**: `Object`
-**default**: `{ context: '.', sources: [], destination: null }`
+**default**: `{ context: '.', sources: [], destination: null, fileName: null }`
 
 Include any external images (those not included in webpack's compilation assets) that you want to be parsed by imagemin.
 If a destination value is not supplied the files are optimized in place. You can optionally set either of these to a function which will be invoked at the last possible second before optimization to grab files that might not exist at the time of writing the config (see #37 for more info).
@@ -183,7 +183,8 @@ module.exports = {
       externalImages: {
         context: 'src', // Important! This tells the plugin where to "base" the paths at
         sources: glob.sync('src/images/**/*.png'),
-        destination: 'src/public/images'
+        destination: 'src/public/images',
+        fileName: '[path][name].[ext]' // (filePath) => filePath.replace('jpg', 'webp') is also possible
       }
     })
   ]

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -164,3 +164,26 @@ function compileRegex (rawTestValue) {
     }
   })
 }
+
+/**
+ * Replaces file name templates for a given path. Inspired by webpack's output.filename config.
+ * @param {String|Function} fileName
+ * @param {String} filePath
+ * @returns {String}
+ */
+export function templatedFilePath (fileName, filePath) {
+  if (typeof fileName === 'function') {
+    return fileName(filePath)
+  }
+
+  if (typeof fileName === 'string') {
+    const originalFilePath = filePath
+
+    return fileName
+      .replace('[path]', originalFilePath.split(path.basename(originalFilePath))[0])
+      .replace('[name]', path.basename(originalFilePath, path.extname(originalFilePath)))
+      .replace('[ext]', path.extname(originalFilePath).split('.')[1])
+  }
+
+  throw new Error('fileName parameter must be a string or a function')
+}


### PR DESCRIPTION
Hey!

i need a way to change the filename for the `externalImage` method. So, i created a new prop `fileName`.

Its possible to pass a string or a simple function to the new property.

Example String:
```javascript
fileName: '[path][name].[ext]'
```
Example Function:
```javascript
fileName: (filePath) => filePath.replace('jpg', 'webp')
```