### PR TITLE
Feature/add typings

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "2.4.0",
   "description": "Webpack plugin to compress images",
   "main": "dist/index.js",
+  "types": "dist/index.d.ts",
   "files": [
     "dist",
     "src"
@@ -10,8 +11,8 @@
   "scripts": {
     "clean": "rimraf dist",
     "test": "standard src/*",
-    "build": "babel src --out-dir dist --source-maps",
-    "prepublishOnly": "babel src --out-dir dist --source-maps"
+    "build": "babel src --out-dir dist --copy-files --source-maps",
+    "prepublishOnly": "babel src --out-dir dist --copy-files --source-maps"
   },
   "engines": {
     "node": ">=4.0.0"
@@ -44,6 +45,7 @@
   },
   "homepage": "https://github.com/Klathmon/imagemin-webpack-plugin#readme",
   "dependencies": {
+    "@types/webpack": "^4.4.24",
     "async-throttle": "^1.1.0",
     "babel-runtime": "^6.18.0",
     "imagemin": "^6.1.0",

--- a/package.json
+++ b/package.json
@@ -45,6 +45,10 @@
   },
   "homepage": "https://github.com/Klathmon/imagemin-webpack-plugin#readme",
   "dependencies": {
+    "@types/imagemin-gifsicle": "^5.2.0",
+    "@types/imagemin-jpegtran": "^5.0.0",
+    "@types/imagemin-optipng": "^5.2.0",
+    "@types/imagemin-svgo": "^7.0.0",
     "@types/webpack": "^4.4.24",
     "async-throttle": "^1.1.0",
     "babel-runtime": "^6.18.0",

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,3 +1,8 @@
+import { Options as GifsicleOptions } from 'imagemin-gifsicle';
+import { Options as JpegTranOptions } from 'imagemin-jpegtran';
+import { Options as OptiPngOptions } from 'imagemin-optipng';
+import { Options as SvgoOptions } from 'imagemin-svgo';
+
 import { Plugin } from 'webpack';
 
 export default ImageminWebpackPugin;
@@ -9,7 +14,7 @@ declare class ImageminWebpackPugin extends Plugin {
 declare namespace ImageminWebpackPugin {
   type TestOption = RegExp | string | (() => boolean);
 
-  // Keeping it as generic object as including all the other types would be too heavy
+  // Generic options for plugins missing typings
   interface ExternalOptions {
     [key: string]: any;
   }
@@ -18,10 +23,10 @@ declare namespace ImageminWebpackPugin {
     disable?: boolean;
     test?: TestOption | TestOption[];
     maxConcurrency?: number;
-    optipng?: ExternalOptions | null;
-    gifsicle?: ExternalOptions | null;
-    jpegtran?: ExternalOptions | null;
-    svgo?: ExternalOptions | null;
+    optipng?: OptiPngOptions | null;
+    gifsicle?: GifsicleOptions | null;
+    jpegtran?: JpegTranOptions | null;
+    svgo?: SvgoOptions | null;
     pngquant?: ExternalOptions | null;
     plugins?: Array<Promise<Buffer>> | [];
   }

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,0 +1,28 @@
+import { Plugin } from 'webpack';
+
+export default ImageminWebpackPugin;
+
+declare class ImageminWebpackPugin extends Plugin {
+  constructor(options: ImageminWebpackPugin.Options);
+}
+
+declare namespace ImageminWebpackPugin {
+  type TestOption = RegExp | string | (() => boolean);
+
+  // Keeping it as generic object as including all the other types would be too heavy
+  interface ExternalOptions {
+    [key: string]: any;
+  }
+
+  interface Options {
+    disable?: boolean;
+    test?: TestOption | TestOption[];
+    maxConcurrency?: number;
+    optipng?: ExternalOptions | null;
+    gifsicle?: ExternalOptions | null;
+    jpegtran?: ExternalOptions | null;
+    svgo?: ExternalOptions | null;
+    pngquant?: ExternalOptions | null;
+    plugins?: Array<Promise<Buffer>> | [];
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -94,6 +94,39 @@
   resolved "https://registry.yarnpkg.com/@sindresorhus/is/-/is-0.7.0.tgz#9a06f4f137ee84d7df0460c1fdb1135ffa6c50fd"
   integrity sha512-ONhaKPIufzzrlNbqtWFFd+jlnemX6lJAgq9ZeiZtS7I1PIf/la7CW4m83rTXRnVnsMbW2k56pGYu7AUFJD9Pow==
 
+"@types/anymatch@*":
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/@types/anymatch/-/anymatch-1.3.0.tgz#d1d55958d1fccc5527d4aba29fc9c4b942f563ff"
+  integrity sha512-7WcbyctkE8GTzogDb0ulRAEw7v8oIS54ft9mQTU7PfM0hp5e+8kpa+HeQ7IQrFbKtJXBKcZ4bh+Em9dTw5L6AQ==
+
+"@types/node@*":
+  version "10.12.21"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-10.12.21.tgz#7e8a0c34cf29f4e17a36e9bd0ea72d45ba03908e"
+  integrity sha512-CBgLNk4o3XMnqMc0rhb6lc77IwShMEglz05deDcn2lQxyXEZivfwgYJu7SMha9V5XcrP6qZuevTHV/QrN2vjKQ==
+
+"@types/tapable@*":
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/@types/tapable/-/tapable-1.0.4.tgz#b4ffc7dc97b498c969b360a41eee247f82616370"
+  integrity sha512-78AdXtlhpCHT0K3EytMpn4JNxaf5tbqbLcbIRoQIHzpTIyjpxLQKRoxU55ujBXAtg3Nl2h/XWvfDa9dsMOd0pQ==
+
+"@types/uglify-js@*":
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/@types/uglify-js/-/uglify-js-3.0.4.tgz#96beae23df6f561862a830b4288a49e86baac082"
+  integrity sha512-SudIN9TRJ+v8g5pTG8RRCqfqTMNqgWCKKd3vtynhGzkIIjxaicNAMuY5TRadJ6tzDu3Dotf3ngaMILtmOdmWEQ==
+  dependencies:
+    source-map "^0.6.1"
+
+"@types/webpack@^4.4.24":
+  version "4.4.24"
+  resolved "https://registry.yarnpkg.com/@types/webpack/-/webpack-4.4.24.tgz#75bc301176066f566ec54151b6101c2b45abb8b2"
+  integrity sha512-yg99CjvB7xZ/iuHrsZ7dkGKoq/FRDzqLzAxKh2EmTem6FWjzrty4FqCqBYuX5z+MFwSaaQGDAX4Q9HQkLjGLnQ==
+  dependencies:
+    "@types/anymatch" "*"
+    "@types/node" "*"
+    "@types/tapable" "*"
+    "@types/uglify-js" "*"
+    source-map "^0.6.0"
+
 abbrev@1:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/abbrev/-/abbrev-1.1.0.tgz#d0554c2256636e2f56e7c2e5ad183f859428d81f"
@@ -5250,9 +5283,10 @@ source-map@^0.5.0, source-map@^0.5.3, source-map@^0.5.6:
   version "0.5.7"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.5.7.tgz#8a039d2d1021d22d1ea14c80d8ea468ba2ef3fcc"
 
-source-map@~0.6.1:
+source-map@^0.6.0, source-map@^0.6.1, source-map@~0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.6.1.tgz#74722af32e9614e9c287a8d0bbde48b5e2f1a263"
+  integrity sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==
 
 sparkles@^1.0.0:
   version "1.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -99,10 +99,51 @@
   resolved "https://registry.yarnpkg.com/@types/anymatch/-/anymatch-1.3.0.tgz#d1d55958d1fccc5527d4aba29fc9c4b942f563ff"
   integrity sha512-7WcbyctkE8GTzogDb0ulRAEw7v8oIS54ft9mQTU7PfM0hp5e+8kpa+HeQ7IQrFbKtJXBKcZ4bh+Em9dTw5L6AQ==
 
+"@types/imagemin-gifsicle@^5.2.0":
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/@types/imagemin-gifsicle/-/imagemin-gifsicle-5.2.0.tgz#349160f17412e26de8d5794e70aad504781ea7d8"
+  integrity sha512-WohEsNMyGYTc+u6WA7KUvX8g+uLgTJOhqteexGdGZ/TPyS65GuCzMJ1RTaSzqG/cIfLFxbxg/HbGBg8YJrNZaw==
+  dependencies:
+    "@types/imagemin" "*"
+
+"@types/imagemin-jpegtran@^5.0.0":
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/@types/imagemin-jpegtran/-/imagemin-jpegtran-5.0.0.tgz#44d98874bdcc3f290ce1e158355f33fc90ac2758"
+  integrity sha512-uwJknBgND9Jx+/d5bJf+mvAjfes0NIDyCeOKFJ9LbEYnp8/PVt0YDGh8K96JemeF84VbhHFxnN62Wz68rVNfFQ==
+  dependencies:
+    "@types/imagemin" "*"
+
+"@types/imagemin-optipng@^5.2.0":
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/@types/imagemin-optipng/-/imagemin-optipng-5.2.0.tgz#83046e0695739661fa738ad253bdbf51bc4f9e9d"
+  integrity sha512-Qn4gTV1fpPG2WIsUIl10yi2prudOuDIx+D+O0H3aKZRcTCwpMjszBVeRWUqkhG5wADhWO4giLut1sFNr3H2XIQ==
+  dependencies:
+    "@types/imagemin" "*"
+
+"@types/imagemin-svgo@^7.0.0":
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/@types/imagemin-svgo/-/imagemin-svgo-7.0.0.tgz#c9ffe209ed7695c9ae4bebef083f47de2cd98c1e"
+  integrity sha512-Uq2T4hHE9PvBLB1lZM1+bZUzPc14XCKKWzQqJ47qe4/iuVHavYX4ig/gbBj8W3ZvRAJcQV3nagfoqFUzzdFD4g==
+  dependencies:
+    "@types/imagemin" "*"
+    "@types/svgo" "*"
+
+"@types/imagemin@*":
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/@types/imagemin/-/imagemin-6.0.0.tgz#c7b72bb08657396884acfac735c204379b0fe0a4"
+  integrity sha512-07dAIxWudAi8dHBS7W5JJ1rj4XR+FBLooq1yXXZo2XTv9kbMHKeDjq1pd9ou4Ui6yBZzfezlNxfJM1++fbc5/A==
+  dependencies:
+    "@types/node" "*"
+
 "@types/node@*":
   version "10.12.21"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-10.12.21.tgz#7e8a0c34cf29f4e17a36e9bd0ea72d45ba03908e"
   integrity sha512-CBgLNk4o3XMnqMc0rhb6lc77IwShMEglz05deDcn2lQxyXEZivfwgYJu7SMha9V5XcrP6qZuevTHV/QrN2vjKQ==
+
+"@types/svgo@*":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@types/svgo/-/svgo-1.0.1.tgz#6095fc0119febcf5920ed9cdacdcc0a0d026e4a5"
+  integrity sha512-tV+xgQS8v4McSQqk+tGDCwTT1Bo/QLqgRPS1M9UgNZHK2cTf6CdwzxcMG7YAQwd/ZPUNgfgvN7tfe4OUv077Lw==
 
 "@types/tapable@*":
   version "1.0.4"


### PR DESCRIPTION
As Typescript gets more and more popular, adding typings to the repository would make importing package in Typescript environments much easier.

I tried to keep it simple and concise and affect as little as possible, the only external dependency being Webpack `@types/webpack` (not Webpack itself).