### PR TITLE
Do not check that the file got smaller

### DIFF
--- a/src/helpers.js
+++ b/src/helpers.js
@@ -11,7 +11,7 @@ const writeFileAsync = promisify(fs.writeFile)
 const mkdirpAsync = promisify(mkdirp)
 
 /**
- * Optimizes a single image, returning the orignal if the "optimized" version is larger
+ * Optimizes a single image
  * @param  {Object}  imageData
  * @param  {Object}  imageminOptions
  * @return {Promise(asset)}
@@ -19,19 +19,12 @@ const mkdirpAsync = promisify(mkdirp)
 export async function optimizeImage (imageData, imageminOptions) {
   // Ensure that the contents i have are in the form of a buffer
   const imageBuffer = (Buffer.isBuffer(imageData) ? imageData : Buffer.from(imageData, 'utf8'))
-  // And get the original size for comparison later to make sure it actually got smaller
-  const originalSize = imageBuffer.length
 
   // Await for imagemin to do the compression
   const optimizedImageBuffer = await imagemin.buffer(imageBuffer, imageminOptions)
 
-  // If the optimization actually produced a smaller file, then return the optimized version
-  if (optimizedImageBuffer.length < originalSize) {
-    return optimizedImageBuffer
-  } else {
-    // otherwize return the orignal
-    return imageBuffer
-  }
+  // Return the optimized version
+  return optimizedImageBuffer
 }
 
 /**


### PR DESCRIPTION
I know the purpose of this plugin is to optimize images, and that usually means making them smaller.

But some plugins, in particular SVGO, sometimes make the image larger on purpose. In particular, some of *its* plugins add data to the SVG. For example, the `prefixIds` plugin prefixes class names and IDs in the SVG so that many SVGs with similar IDs on their elements can be used inline in a single document without conflicting with each other. This necessarily adds something to the filesize.

Often the amount added is less than the amount taken away by other optimizations, and so everything seems fine. But sometimes the input SVG was already sufficiently optimized that more is being added than taken away.

In these cases, imagemin-webpack-plugin was discarding the optimizations, and the original image was left alone. This can lead to all sorts of bugs (IDs colliding, elements within the SVG not being addressable since you expected them to be prefixed, accessibility attributes not having been added to the SVG element, wrong display size due to viewBox not being added, ...), and these are very frustrating and difficult to trace.

imagemin-webpack-plugin shouldn't care about whether the image got smaller. That corcern lies solely with the individual optimization tools like SVGO, Optipng, etc. Instead of testing for a smaller file in imagemin-webpack-plugin, it's better to file bugs against any of those tools which sometimes output larger files even when undesirable.

----

I thought the bug was with SVGO (see https://github.com/svg/svgo/issues/991) when I first came across this issue a year ago. Only today did I finally trace it to imagemin-webpack-plugin, after @missmatsuko was facing the same issue.

I propose removing this check, as implemented in this patch.