### PR TITLE
Add "onlyUseIfSmaller" option

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,6 +254,15 @@ module.exports = {
 }
 ```
 
+#### options.onlyUseIfSmaller
+
+**type**: `Boolean`
+**default**: `false`
+
+If set to `true`, this plugin will use the original image if the optimization process makes it larger.
+
+**`true` used to be the default behavior in version 2 of this plugin!**
+
 ### Troubleshooting
 
 If you get an error similar to `Error in parsing SVG: Unquoted attribute value` while using SVGO, you most likely have un-quoted attributes in the SVG image. A workaround can be found [here](https://github.com/Klathmon/imagemin-webpack-plugin/issues/25) from @vzaidman. They also made an issue upstream which should fix it at the source [here](https://github.com/svg/svgo/issues/678).

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "imagemin-webpack-plugin",
-  "version": "2.4.2",
+  "version": "3.0.0-beta.0",
   "description": "Webpack plugin to compress images",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -26,12 +26,11 @@ export async function optimizeImage (imageData, imageminOptions) {
   // Await for imagemin to do the compression
   const optimizedImageBuffer = await imagemin.buffer(imageBuffer, imageminOptions)
 
-  // If the optimization actually produced a smaller file, then return the optimized version
-  if (imageminOptions.onlyUseIfSmaller && optimizedImageBuffer.length < originalSize) {
-    return optimizedImageBuffer
-  } else {
-    // otherwize return the orignal
+  // If onlyUseIfSmaller is true, and the optimization actually produced a LARGER file, then return the original version
+  if (imageminOptions.onlyUseIfSmaller && optimizedImageBuffer.length > originalSize) {
     return imageBuffer
+  } else {
+    return optimizedImageBuffer
   }
 }
 

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -11,7 +11,8 @@ const writeFileAsync = promisify(fs.writeFile)
 const mkdirpAsync = promisify(mkdirp)
 
 /**
- * Optimizes a single image, returning the orignal if the "optimized" version is larger
+ * Optimizes a single image
+ * returns the orignal if the "optimized" version is larger (only if the onlyUseIfSmaller option is true)
  * @param  {Object}  imageData
  * @param  {Object}  imageminOptions
  * @return {Promise(asset)}
@@ -26,7 +27,7 @@ export async function optimizeImage (imageData, imageminOptions) {
   const optimizedImageBuffer = await imagemin.buffer(imageBuffer, imageminOptions)
 
   // If the optimization actually produced a smaller file, then return the optimized version
-  if (optimizedImageBuffer.length < originalSize) {
+  if (imageminOptions.onlyUseIfSmaller && optimizedImageBuffer.length < originalSize) {
     return optimizedImageBuffer
   } else {
     // otherwize return the orignal

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -17,7 +17,7 @@ const mkdirpAsync = promisify(mkdirp)
  * @param  {Object}  imageminOptions
  * @return {Promise(asset)}
  */
-export async function optimizeImage (imageData, imageminOptions) {
+export async function optimizeImage (imageData, { imageminOptions, onlyUseIfSmaller }) {
   // Ensure that the contents i have are in the form of a buffer
   const imageBuffer = (Buffer.isBuffer(imageData) ? imageData : Buffer.from(imageData, 'utf8'))
   // And get the original size for comparison later to make sure it actually got smaller
@@ -27,7 +27,7 @@ export async function optimizeImage (imageData, imageminOptions) {
   const optimizedImageBuffer = await imagemin.buffer(imageBuffer, imageminOptions)
 
   // If onlyUseIfSmaller is true, and the optimization actually produced a LARGER file, then return the original version
-  if (imageminOptions.onlyUseIfSmaller && optimizedImageBuffer.length > originalSize) {
+  if (onlyUseIfSmaller && optimizedImageBuffer.length > originalSize) {
     return imageBuffer
   } else {
     return optimizedImageBuffer

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -38,5 +38,6 @@ declare namespace ImageminWebpackPlugin {
     minFileSize?: number;
     maxFileSize?: number;
     cacheFolder?: string;
+    onlyUseIfSmaller?: boolean;
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -21,7 +21,6 @@ import {
 
 export default class ImageminPlugin {
   constructor (options = {}) {
-    // I love ES2015!
     const {
       disable = false,
       test = /.*/,
@@ -41,7 +40,8 @@ export default class ImageminPlugin {
       svgo = {},
       pngquant = null,
       externalImages = {},
-      cacheFolder = null
+      cacheFolder = null,
+      onlyUseIfSmaller = false
     } = options
 
     this.options = {
@@ -58,7 +58,8 @@ export default class ImageminPlugin {
         fileName: null,
         ...externalImages
       },
-      cacheFolder
+      cacheFolder,
+      onlyUseIfSmaller
     }
 
     // As long as the options aren't `null` then include the plugin. Let the destructuring above

--- a/src/index.js
+++ b/src/index.js
@@ -139,7 +139,7 @@ export default class ImageminPlugin {
         // Use the helper function to get the file from cache if possible, or
         // run the optimize function and store it in the cache when done
         let optimizedImageBuffer = await getFromCacheIfPossible(cacheFolder, assetSource, () => {
-          return optimizeImage(assetSource, this.options.imageminOptions)
+          return optimizeImage(assetSource, this.options)
         })
 
         // Then write the optimized version back to the asset object as a "raw source"


### PR DESCRIPTION
In response to #89, this PR changes the default functionality of this plugin to NOT discard images if they are larger after the optimization process, and adds an option that re-enables that functionality if needed.

I don't want to merge this until I get at least a few confirmations that it works correctly from people and isn't causing any issues.

This will be a major version bump when released, so 